### PR TITLE
Sets preferred install path of build agent

### DIFF
--- a/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
+++ b/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
@@ -114,8 +114,15 @@ do {
 } 
 while ($retries -le $retryCount)
 
-# Construct the agent folder under the main (hardcoded) C: drive.
-$agentInstallationPath = Join-Path "C:" $AgentName 
+# Identify correct destination drive letter for Agent installation.
+Try {
+    $volume = "$(get-volume | where-object {($_.SizeRemaining -GE 350GB) -and ($_.driveletter -ne $($env:SystemDrive).trim(':'))} -erroraction stop | select -first 1 -ExpandProperty DriveLetter):"
+}
+Catch {
+    $volume = $env:systemdrive
+}
+# Construct the agent folder under a volume .
+$agentInstallationPath = Join-Path $volume $AgentName 
 # Create the directory for this agent.
 New-Item -ItemType Directory -Force -Path $agentInstallationPath 
 


### PR DESCRIPTION
Defaults to non system drive, to keep build artefact accumulation from filling up the OS drive and killing the VM.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

